### PR TITLE
Fix/filter issues

### DIFF
--- a/Backend/pom.xml
+++ b/Backend/pom.xml
@@ -42,6 +42,17 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+		<dependency>
+			<groupId>com.h2database</groupId>
+			<artifactId>h2</artifactId>
+			<scope>test</scope>
+		</dependency>
+
 	</dependencies>
 
 	<build>

--- a/Backend/src/main/java/com/example/trading_journal/components/DataLoader.java
+++ b/Backend/src/main/java/com/example/trading_journal/components/DataLoader.java
@@ -11,6 +11,8 @@ import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.ApplicationRunner;
 import org.springframework.stereotype.Component;
 
+import java.time.LocalDate;
+
 @Component
 public class DataLoader implements ApplicationRunner {
 
@@ -36,10 +38,10 @@ public class DataLoader implements ApplicationRunner {
         traderRepository.save(trader2);
         traderRepository.save(trader3);
 
-        Trade trade1 = new Trade("EUR/USD1",650,344,333,241,"14/10/2024");
-        Trade trade2 = new Trade("USD/JPY1",50,34,3,4,"13/10/2024");
-        Trade trade3 = new Trade("GBP/USD1",86,45,30,20,"12/10/2024");
-        Trade trade4 = new Trade("AUD/USD1",65,44,33,41,"11/10/2024");
+        Trade trade1 = new Trade("EUR/USD1",650,344,333,241,LocalDate.of(2024,10,14));
+        Trade trade2 = new Trade("USD/JPY1",50,34,3,4,LocalDate.of(2024,10,13));
+        Trade trade3 = new Trade("GBP/USD1",86,45,30,20,LocalDate.of(2024,10,12));
+        Trade trade4 = new Trade("AUD/USD1",65,44,33,41,LocalDate.of(2024,10,12));
 
 
         tradeRepository.save(trade4);
@@ -47,13 +49,17 @@ public class DataLoader implements ApplicationRunner {
         tradeRepository.save(trade3);
         tradeRepository.save(trade2);
 
-        Issue goodNote = new Issue("14/10/2024","Issue 1","Great trade, I analysed well!");
-        Issue okayNote = new Issue("13/10/2024","Issue 2","This was quite average, I could've have improved here");
-        Issue badNote = new Issue("12/10/2024","Issue 3","This is one of the worst I've done :( ");
+        Issue goodIssue = new Issue(LocalDate.of(2024,10,14),"Issue 1","Great trade, I analysed well!");
+        Issue okayIssue = new Issue(LocalDate.of(2024,10,13),"Issue 2","This was quite average, I could've have improved here");
+        Issue badIssue = new Issue(LocalDate.of(2024,10,12),"Issue 3","This is one of the worst I've done :( ");
+        Issue longAgoIssue = new Issue(LocalDate.of(2024,5,3),"Issue 3","This is one of the worst I've done :( ");
+        Issue weekAgoIssue = new Issue(LocalDate.of(2024,11,16),"Issue 3","This is one of the worst I've done :( ");
 
-        issueRepository.save(goodNote);
-        issueRepository.save(okayNote);
-        issueRepository.save(badNote);
+        issueRepository.save(goodIssue);
+        issueRepository.save(okayIssue);
+        issueRepository.save(badIssue);
+        issueRepository.save(longAgoIssue);
+        issueRepository.save(weekAgoIssue);
     }
 
 }

--- a/Backend/src/main/java/com/example/trading_journal/controllers/IssueController.java
+++ b/Backend/src/main/java/com/example/trading_journal/controllers/IssueController.java
@@ -2,14 +2,10 @@ package com.example.trading_journal.controllers;
 
 import com.example.trading_journal.models.Issue;
 import com.example.trading_journal.services.IssueService;
-import org.apache.coyote.Response;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 import java.util.Optional;
@@ -37,9 +33,13 @@ public class IssueController {
         }
     }
 
-    @GetMapping("/date/{tradeDate}")
-    public ResponseEntity<List<Issue>> getIssueByDate(@PathVariable String tradeDate){
-        List<Issue> issues = issueService.getIssueByDate(tradeDate);
+    @GetMapping("/filter")
+    public ResponseEntity<List<Issue>> getIssueByFilterStatus(@RequestParam String status){
+
+        List<Issue> issues = issueService.getIssueByFilter(status);
+        if(issues == null){
+            return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
+        }
         if(issues.isEmpty()){
             return new ResponseEntity<>(HttpStatus.NOT_FOUND);
         } else {

--- a/Backend/src/main/java/com/example/trading_journal/models/Issue.java
+++ b/Backend/src/main/java/com/example/trading_journal/models/Issue.java
@@ -4,6 +4,8 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import jakarta.persistence.*;
 
+import java.time.LocalDate;
+
 @Entity
 public class Issue {
 
@@ -18,7 +20,7 @@ public class Issue {
    private String issueDescription;
 
    @Column(name = "tradeDate")
-   private String tradeDate;
+   private LocalDate tradeDate;
 
    @JsonIgnore
    @ManyToOne
@@ -27,17 +29,17 @@ public class Issue {
 
     public Issue() {}
 
-    public Issue(String tradeDate, String issueName, String issueDescription) {
+    public Issue(LocalDate tradeDate, String issueName, String issueDescription) {
         this.tradeDate = tradeDate;
         this.issueName = issueName;
         this.issueDescription = issueDescription;
     }
 
-    public String getTradeDate(){
+    public LocalDate getTradeDate(){
         return tradeDate;
     }
 
-    public void setTradeDate(String tradeDate){
+    public void setTradeDate(LocalDate tradeDate){
         this.tradeDate = tradeDate;
     }
 
@@ -72,4 +74,5 @@ public class Issue {
     public void setTrade(Trade trade) {
         this.trade = trade;
     }
+
 }

--- a/Backend/src/main/java/com/example/trading_journal/models/Trade.java
+++ b/Backend/src/main/java/com/example/trading_journal/models/Trade.java
@@ -3,6 +3,7 @@ package com.example.trading_journal.models;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import jakarta.persistence.*;
 
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -31,7 +32,7 @@ public class Trade {
     private double takeProfit;
 
     @Column(name = "trade_date")
-    private String tradeDate;
+    private LocalDate tradeDate;
 
     @JsonIgnoreProperties({"issue"})
     @OneToMany(mappedBy = "trade", cascade = CascadeType.ALL)
@@ -41,7 +42,7 @@ public class Trade {
 
     public Trade(){}
 
-    public Trade(String name, double entryPoint, double exitPoint, double stopLoss, double takeProfit, String tradeDate) {
+    public Trade(String name, double entryPoint, double exitPoint, double stopLoss, double takeProfit, LocalDate tradeDate) {
         this.name = name;
         this.entryPoint = entryPoint;
         this.exitPoint = exitPoint;
@@ -108,11 +109,11 @@ public class Trade {
         this.takeProfit = takeProfit;
     }
 
-    public String getTradeDate() {
+    public LocalDate getTradeDate() {
         return tradeDate;
     }
 
-    public void setTradeDate(String tradeDate) {
+    public void setTradeDate(LocalDate tradeDate) {
         this.tradeDate = tradeDate;
     }
 

--- a/Backend/src/main/java/com/example/trading_journal/models/TradeDTO.java
+++ b/Backend/src/main/java/com/example/trading_journal/models/TradeDTO.java
@@ -1,5 +1,7 @@
 package com.example.trading_journal.models;
 
+import java.time.LocalDate;
+
 public class TradeDTO {
 
     private String name;
@@ -7,14 +9,14 @@ public class TradeDTO {
     private double exitPoint;
     private double stopLoss;
     private double takeProfit;
-    private String tradeDate;
+    private LocalDate tradeDate;
     private String issueName;
     private String issueDescription;
 
 
     public TradeDTO(){}
 
-    public TradeDTO(String name, double entryPoint, int exitPoint, int stopLoss, int takeProfit, String tradeDate, String issueName, String issueDescription) {
+    public TradeDTO(String name, double entryPoint, int exitPoint, int stopLoss, int takeProfit, LocalDate tradeDate, String issueName, String issueDescription) {
         this.name = name;
         this.entryPoint = entryPoint;
         this.exitPoint = exitPoint;
@@ -65,11 +67,11 @@ public class TradeDTO {
         this.takeProfit = takeProfit;
     }
 
-    public String getTradeDate() {
+    public LocalDate getTradeDate() {
         return tradeDate;
     }
 
-    public void setTradeDate(String tradeDate) {
+    public void setTradeDate(LocalDate tradeDate) {
         this.tradeDate = tradeDate;
     }
 

--- a/Backend/src/main/java/com/example/trading_journal/repositories/IssueRepository.java
+++ b/Backend/src/main/java/com/example/trading_journal/repositories/IssueRepository.java
@@ -2,10 +2,15 @@ package com.example.trading_journal.repositories;
 
 import com.example.trading_journal.models.Issue;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
 
+import java.time.LocalDate;
 import java.util.List;
-import java.util.Optional;
 
+@Repository
 public interface IssueRepository extends JpaRepository<Issue, Long> {
-    List<Issue> getIssueByTradeDate(String tradeDate);
+    @Query(value = "SELECT x FROM Issue  x WHERE x.tradeDate >=:startDate")
+    List<Issue> findAllWithStartDateAfter(@Param("startDate") LocalDate startDate);
 }

--- a/Backend/src/main/java/com/example/trading_journal/repositories/TradeRepository.java
+++ b/Backend/src/main/java/com/example/trading_journal/repositories/TradeRepository.java
@@ -2,6 +2,8 @@ package com.example.trading_journal.repositories;
 
 import com.example.trading_journal.models.Trade;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
+@Repository
 public interface TradeRepository extends JpaRepository<Trade, Long> {
 }

--- a/Backend/src/main/java/com/example/trading_journal/repositories/TraderRepository.java
+++ b/Backend/src/main/java/com/example/trading_journal/repositories/TraderRepository.java
@@ -2,6 +2,8 @@ package com.example.trading_journal.repositories;
 
 import com.example.trading_journal.models.Trader;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
+@Repository
 public interface TraderRepository extends JpaRepository<Trader, Long> {
 }

--- a/Backend/src/main/java/com/example/trading_journal/services/DateFilterService.java
+++ b/Backend/src/main/java/com/example/trading_journal/services/DateFilterService.java
@@ -1,0 +1,32 @@
+package com.example.trading_journal.services;
+
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+
+@Service
+public class DateFilterService {
+
+    public LocalDate getStartDate(String status){
+        LocalDate startDate = LocalDate.now();
+        String statusLCase = status.toLowerCase();
+
+        if ("past-week".equals(statusLCase)) {
+             return startDate.minusWeeks(1);
+        } else if ("past-month".equals(statusLCase)) {
+            return startDate.minusMonths(1);
+
+        } else if ("past-3-months".equals(statusLCase)) {
+            return startDate.minusMonths(3);
+
+        } else if ("past-6-months".equals(statusLCase)) {
+            return startDate.minusMonths(6);
+
+        } else if ("past-year".equals(statusLCase)) {
+            return startDate.minusYears(1);
+        } else {
+            return startDate;
+        }
+    }
+}
+

--- a/Backend/src/main/java/com/example/trading_journal/services/IssueService.java
+++ b/Backend/src/main/java/com/example/trading_journal/services/IssueService.java
@@ -5,6 +5,7 @@ import com.example.trading_journal.repositories.IssueRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 
@@ -14,6 +15,9 @@ public class IssueService {
     @Autowired
     IssueRepository issueRepository;
 
+    @Autowired
+    DateFilterService dateFilterService;
+
     public List<Issue> getAllIssues(){
         return issueRepository.findAll();
     }
@@ -22,7 +26,8 @@ public class IssueService {
         return issueRepository.findById(id);
     }
 
-    public List<Issue> getIssueByDate(String tradeDate){
-        return issueRepository.getIssueByTradeDate(tradeDate);
+    public List<Issue> getIssueByFilter(String filter){
+        LocalDate startDate = dateFilterService.getStartDate(filter);
+        return issueRepository.findAllWithStartDateAfter(startDate);
     }
 }

--- a/Backend/src/test/java/com/example/trading_journal/DataFilterServiceTest.java
+++ b/Backend/src/test/java/com/example/trading_journal/DataFilterServiceTest.java
@@ -1,0 +1,41 @@
+package com.example.trading_journal;
+
+import com.example.trading_journal.services.DateFilterService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+public class DataFilterServiceTest {
+
+    @Autowired
+    DateFilterService dateFilterService;
+    
+    @Test
+    void canCalculateStartDate(){
+        LocalDate expectedStartDate = LocalDate.of(2024,11,17);
+        LocalDate actualStartDate = LocalDate.now();
+        System.out.println(actualStartDate);
+        assertThat(expectedStartDate).isEqualTo(actualStartDate);
+    }
+
+    @Test
+    void canCalculateDateAWeekAgo(){
+        String filter = "Past Week";
+        LocalDate startDate = dateFilterService.getStartDate(filter);
+        assertThat(startDate).isEqualTo("2024-11-10");
+    }
+
+    @Test
+    void canCalculateDateAMonthAgo(){
+        String filter = "Past month";
+        LocalDate startDate = dateFilterService.getStartDate(filter);
+        assertThat(startDate).isEqualTo("2024-10-17");
+    }
+
+
+}

--- a/Backend/src/test/java/com/example/trading_journal/IssueRepositoryTest.java
+++ b/Backend/src/test/java/com/example/trading_journal/IssueRepositoryTest.java
@@ -1,0 +1,44 @@
+package com.example.trading_journal;
+
+import com.example.trading_journal.models.Issue;
+import com.example.trading_journal.repositories.IssueRepository;
+import com.example.trading_journal.services.DateFilterService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@SpringBootTest
+public class IssueRepositoryTest {
+
+    @Autowired
+    IssueRepository issueRepository;
+
+    @Autowired
+    DateFilterService dateFilterService;
+    @BeforeEach
+    public void setUp() {
+        issueRepository.deleteAll();
+
+        issueRepository.save(new Issue(LocalDate.of(2024, 10, 14), "Issue 1", "Great trade, I analysed well!"));
+        issueRepository.save(new Issue(LocalDate.of(2024, 10, 13), "Issue 2", "This was quite average, I could've have improved here"));
+        issueRepository.save(new Issue(LocalDate.of(2024, 11, 16), "Issue 3", "This is one of the worst I've done :( "));
+        issueRepository.save(new Issue(LocalDate.of(2024, 5, 3), "Issue 3", "This is one of the worst I've done :( "));
+    }
+
+    @Test
+    void canFindAllWithStartDateAfter() {
+        String filter = "past-week";
+        LocalDate startDate = dateFilterService.getStartDate(filter);
+        List<Issue> issues = issueRepository.findAllWithStartDateAfter(startDate);
+        assertThat(issues).hasSize(1);
+        assertThat(issues.get(0).getTradeDate()).isAfterOrEqualTo(startDate);
+
+    }
+}
+

--- a/Backend/src/test/resources/application.properties
+++ b/Backend/src/test/resources/application.properties
@@ -1,0 +1,3 @@
+spring.datasource.url=jdbc:h2:mem:testdb
+spring.datasource.driverClassName=org.h2.Driver
+spring.jpa.database-platform=org.hibernate.dialect.H2Dialect


### PR DESCRIPTION
**CHALLENGE**:

- Filtering only worked in PgAdmin3 but it provided wrong issues in Postman.

**STEPS TO DEBUG**:

1. Tested the custom query in the issue repository, directly in PgAdmin to see if this was the underlying problem. Since the query worked as expected, it ruled out any issues with the underlying database query
2. Created Test suites for the Issue Service and newly created Date Filter Service to check if the logic here was the problem. The tests passed meaning it also was not the root cause.
3. This left the Issue Controller to check. To investigate the problem, the function was modified to return the filter status and see if it was being read as something different. It was as expected which meant it was ruled out.
4. The only potential cause left were the endpoints. The error was that more than one handler method was mapped to "/issues" resulting in incorrect results when sending the get requests in Postman. 

**SOLUTION**:

- Changed the endpoint for getIssueByFilterStatus method to map to `"/filters"` instead of `"/issues"` and this resolved the issue of confusion triggering the correct HTTP Requests. closes #63. 