### PR TITLE
Fix/dashboard styling

### DIFF
--- a/Frontend/src/components/widgets/IssueWidget.tsx
+++ b/Frontend/src/components/widgets/IssueWidget.tsx
@@ -22,19 +22,17 @@ const IssueWidget:React.FC<IssueWidgetProps> = ({ issues }) => {
                 <a href="/issues">
                     <li key={recentIssue.issueId} className="recent-issue">
                         <span className="icon"><FontAwesomeIcon icon={faBug} /></span>
-                        <span className="trade-name">{recentIssue.issueName}</span>
+                        <p className="trade-name">{recentIssue.issueName}</p>
                     </li>
                 </a>
-            )
+            ) 
     })
 
     return(
         <div className="recent-issues">
             <h3 className="widget-title">Recent Issues</h3>
-            <div className="recent-issue-list">
-
-            {mappedLatestIssues}
-            </div>
+            {mappedLatestIssues.length ? 
+            <div className="recent-issue-list">{mappedLatestIssues}</div> : <p className="unavailable-display">---  No issues have been added  ---</p>}
         </div>
     )
 }

--- a/Frontend/src/components/widgets/TradeWidget.tsx
+++ b/Frontend/src/components/widgets/TradeWidget.tsx
@@ -17,7 +17,7 @@ const TradeWidget:React.FC<TradeWidgetProps>= ({trades}) => {
         <a href="/trades">
             <li key={recentTrade.tradeId} className="recent-trade">
                 <span className="icon"><FontAwesomeIcon icon={faMoneyBillTrendUp} /></span>
-                <span className="trade-name">{recentTrade.name}</span>
+                <p className="trade-name">{recentTrade.name}</p>
             </li>
         </a> 
         )
@@ -26,10 +26,8 @@ const TradeWidget:React.FC<TradeWidgetProps>= ({trades}) => {
     return(
         <div className="recent-trades">
             <h3 className="widget-title">Recent Trades</h3>
-            <div className="recent-trade-list">
-
-            {mappedLatestTrades}
-            </div>
+            {mappedLatestTrades.length > 0 ?
+            <div className="recent-trade-list">{mappedLatestTrades}</div> : <p className="unavailable-display">---  No trades have been added  ---</p>}  
         </div>
     )
 }

--- a/Frontend/src/components/widgets/widgets.css
+++ b/Frontend/src/components/widgets/widgets.css
@@ -17,6 +17,7 @@
     margin: 1.5rem 2rem 0rem 2rem;
     box-shadow: 1px 3px 10px 3px var(--shadow-color);
     align-items: center;
+    height: 11.55rem;
 }
 
 

--- a/Frontend/src/components/widgets/widgets.css
+++ b/Frontend/src/components/widgets/widgets.css
@@ -8,7 +8,7 @@
 
 
 .recent-trades, .recent-issues {
-    display: flex;
+    display: inline-block;
     flex-direction: column;
     flex: 1;
     background-color: white;
@@ -22,40 +22,54 @@
 
 
 .recent-trade, .recent-issue {
-    display: flex;
+    margin: 0.3rem 0rem 0.3rem 2rem;
+    padding: 0.3rem 3rem;
     align-items: center;
-    justify-content: flex-start;
-    padding: 0.5rem;
     font-size: large;
-    width: 100%; 
     font-weight: 400;
-    color: black;
+    color: rgb(91, 82, 82);
+    list-style: none;
+    display: flex;
+    justify-content: space-around;
+    background-color: rgba(128, 128, 128, 0.119);
+    width: 90%;
 }
 
 .recent-trade:hover, .recent-issue:hover {
-    border: 2px dotted var(--shadow-color);
+    background-color: #76afff42;
     border-radius: 2px;
 }
 
+.recent-trade:active, .recent-issue:active {
+    transform: translateY(2px);
+}
 .widget-title {
-    font-size: x-large;
-    font-weight: 600;
+    font-size: 1.3rem;
+    font-weight: 400;
     font-family: Roboto, sans-serif;
     text-align: center;
-    margin-bottom: 0.3rem;
     color: var(--button-color);
+    margin: 0.2rem;
 }
 
 .icon {
-    padding-right: 8rem; 
-    display: inline-block;
+    display: inline-flex;
+    justify-content: center;
+    padding-left: 5rem;
 }
 
-.trade-name {
-    display: inline-block;
-    text-align: left; 
+li > p {
+    display: inline-flex;
+    width: 80%;
+    justify-content:flex-start;
+    padding-left: 6rem;
+    /* border: 1px solid blue; */
 }
 
-hr {
-    width: 100%;
+.unavailable-display {
+    color: gray;
+    font-size: 1rem;      
+    font-style: italic;   
+    text-align: center;   
+    margin-top: 40px; 
 }

--- a/Frontend/src/index.css
+++ b/Frontend/src/index.css
@@ -13,7 +13,7 @@
   --border-color: #433a69;
   --dashboard-color: #C5DCFC;
   --nav-color: #64A1F7;
-  --shadow-color: #719AD3;
+  --shadow-color: #719ad390;
   --button-color: #0034A3;
   --tradepage-color: #719AD3;
   --tradepage-color1: #5f1a4c;

--- a/Frontend/src/pages/Home/TradeForm.css
+++ b/Frontend/src/pages/Home/TradeForm.css
@@ -4,11 +4,9 @@
     grid-template-rows: max-content;
     grid-row: 2 / 3;
     background-color: white;
-    margin: 2rem 3.4rem 1.3rem 4.3rem;
+    margin: 2rem 3.4rem 1.3rem 3.4rem;
     height: 27rem;
     border-radius: 1rem;
-    /* padding: 1rem; */
-    /* padding: 1rem 1.5rem 0rem 1.5rem; */
     box-shadow: 1px 3px 10px 3px var(--shadow-color);
 }
 
@@ -36,7 +34,6 @@
     display: flex;
     flex-wrap: wrap;
     justify-content: space-between;
-    /* padding: 0.2rem; */
 }
 
 .label-input-pair:first-of-type input{
@@ -95,12 +92,12 @@
     border: 1px solid grey;
     border-radius: 3px;
     margin-top: 0.8rem;
-    /* margin-bottom: 0.7rem; */
     font-family: segoe UI;
     resize: none;
     color: var(--button-color);
     font-weight: 600;
 }
+
 #form-title {
     font-family: Roboto, sans-serif;
     font-size: x-large;
@@ -147,7 +144,6 @@
     box-shadow: none;
 }
 
-/*Submit button*/
 .issue-fields > button{ 
     background-color: var(--button-color);
     box-shadow: 1px 2px 2px rgb(4, 4, 55);

--- a/Frontend/src/pages/Issues/IssuePage.css
+++ b/Frontend/src/pages/Issues/IssuePage.css
@@ -32,16 +32,6 @@
     font-family: Georgia, 'Times New Roman', Times, serif;
 }
 
-
-.icon {
-    background-color: rgba(80, 152, 235, 0.5);
-    border-radius: 0.1rem;
-    position: absolute;
-    right: 35px;
-    bottom: 20px;
-    padding: 0.2rem 0.6rem;
-}
-
 .button :hover {
     background-color: rgba(150, 179, 237, 0.833);
 }


### PR DESCRIPTION
realigns icon to be next to the trades/issues in the widgets. Redesigns it so its more cohesive with the rest of the page. Finally it renders a text to let users no there are no trades or widgets available if none have been added yet. This resolves the changing widget sizes depending on whether there are trades/issues or not.